### PR TITLE
Use https for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/1Remote/VncSharpCore.git
 [submodule "Shawn.Utils"]
 	path = Shawn.Utils
-	url = git@github.com:VShawn/Shawn.Utils.git
+	url = https://github.com/VShawn/Shawn.Utils.git


### PR DESCRIPTION
This PR changes the submodule for Shawn.Utils to use https clone URL. This fixes issues cloning the 1Remote repo.