### PR TITLE
Fix the bug that ssh private key cannot be modified in UI

### DIFF
--- a/Ui/View/Editor/Forms/SftpFormView.xaml.cs
+++ b/Ui/View/Editor/Forms/SftpFormView.xaml.cs
@@ -2,6 +2,7 @@
 using System.Windows;
 using System.Windows.Controls;
 using _1RM.Model.Protocol;
+using Shawn.Utils;
 using Shawn.Utils.Wpf.FileSystem;
 
 namespace _1RM.View.Editor.Forms
@@ -31,7 +32,7 @@ namespace _1RM.View.Editor.Forms
 
         private void ButtonOpenPrivateKey_OnClick(object sender, RoutedEventArgs e)
         {
-            if (DataContext is SFTP sftp)
+            if (DataContext is SftpFormViewModel { New: var sftp })
             {
                 var path = SelectFileHelper.OpenFile(filter: "ppk|*.*", currentDirectoryForShowingRelativePath: Environment.CurrentDirectory);
                 if (path == null) return;
@@ -41,7 +42,7 @@ namespace _1RM.View.Editor.Forms
 
         private void CbUsePrivateKey_OnChecked(object sender, RoutedEventArgs e)
         {
-            if (sender is CheckBox cb && DataContext is SFTP sftp)
+            if (sender is CheckBox cb && DataContext is SftpFormViewModel { New: var sftp })
             {
                 if (cb.IsChecked == false)
                 {

--- a/Ui/View/Editor/Forms/SshFormView.xaml.cs
+++ b/Ui/View/Editor/Forms/SshFormView.xaml.cs
@@ -17,7 +17,7 @@ namespace _1RM.View.Editor.Forms
             InitializeComponent();
             Loaded += (sender, args) =>
             {
-                if (DataContext is SSH ssh)
+                if (DataContext is SshFormViewModel { New: var ssh })
                 {
                     CbUsePrivateKey.IsChecked = false;
                     if (ssh.PrivateKey == ssh.ServerEditorDifferentOptions)
@@ -35,9 +35,9 @@ namespace _1RM.View.Editor.Forms
 
         private void ButtonOpenPrivateKey_OnClick(object sender, RoutedEventArgs e)
         {
-            if (DataContext is SSH ssh)
+            if (DataContext is SshFormViewModel { New: var ssh })
             {
-                    var path = SelectFileHelper.OpenFile(filter: "ppk|*.*", currentDirectoryForShowingRelativePath: Environment.CurrentDirectory);
+                var path = SelectFileHelper.OpenFile(filter: "ppk|*.*", currentDirectoryForShowingRelativePath: Environment.CurrentDirectory);
                 if (path == null) return;
                 ssh.PrivateKey = path;
             }
@@ -45,7 +45,7 @@ namespace _1RM.View.Editor.Forms
 
         private void CbUsePrivateKey_OnChecked(object sender, RoutedEventArgs e)
         {
-            if (sender is CheckBox cb && DataContext is SSH ssh)
+            if (sender is CheckBox cb && DataContext is SshFormViewModel { New: var ssh })
                 if (cb.IsChecked == false)
                 {
                     ssh.PrivateKey = "";


### PR DESCRIPTION
`DataContext` of `SshFormView.xaml` has already been changed to an instance of SshFormViewModel, the previous one (Protocol.SSH ) is in property `New` .