### PR TITLE
Remove  unnecessary direction message

### DIFF
--- a/Ui/View/Host/ProtocolHosts/VmFileTransmitHost.cs
+++ b/Ui/View/Host/ProtocolHosts/VmFileTransmitHost.cs
@@ -781,8 +781,6 @@ namespace _1RM.View.Host.ProtocolHosts
                             return;
 
                         var fbd = new FolderBrowserDialog();
-                        fbd.Description = IoC.Get<ILanguageService>()
-                            .Translate("file_transmit_host_message_select_files_to_upload");
                         fbd.ShowNewFolderButton = false;
                         if (fbd.ShowDialog() == System.Windows.Forms.DialogResult.OK)
                         {


### PR DESCRIPTION
Unnecessary (incorrect) direction message is displayed in the folder selection dialog box when "Select a folder to upload" in FTP/SFTP.

<img width="591" alt="2024-12-05 01 59 39" src="https://github.com/user-attachments/assets/4787a118-699c-4e7d-9dc2-91b29a09e193">
