### PR TITLE
Add scrollbar to Options view (Fix #780)

### DIFF
--- a/Ui/View/Settings/DataSource/DataSourceView.xaml
+++ b/Ui/View/Settings/DataSource/DataSourceView.xaml
@@ -172,6 +172,7 @@
         </DataGrid>
 
 
+        <ScrollViewer>
         <StackPanel Orientation="Horizontal" VerticalAlignment="Top" Height="35" HorizontalAlignment="Right">
 
             <!--SET DATA CHECK PERIOD-->
@@ -240,5 +241,7 @@
                 </Hyperlink>
             </TextBlock>
         </StackPanel>
+
+        </ScrollViewer>
     </Grid>
 </UserControl>

--- a/Ui/View/Settings/General/GeneralSettingView.xaml
+++ b/Ui/View/Settings/General/GeneralSettingView.xaml
@@ -11,6 +11,8 @@
              d:DataContext="{d:DesignInstance local:GeneralSettingViewModel}"
              d:DesignHeight="850" d:DesignWidth="800">
     <Grid Background="{DynamicResource BackgroundBrush}">
+        <ScrollViewer>
+
         <StackPanel>
 
             <TextBlock Text="{DynamicResource system_options_general_title}" Style="{StaticResource BlockTitleColumn}" />
@@ -189,5 +191,7 @@
                 <CheckBox Grid.Column="1" IsChecked="{Binding CopyPortWhenCopyAddress, Mode=TwoWay}" Content="{DynamicResource 'Copy the port along with the address when copying'}" VerticalAlignment="Center"></CheckBox>
             </Grid>
         </StackPanel>
+
+        </ScrollViewer>
     </Grid>
 </UserControl>

--- a/Ui/View/Settings/Launcher/LauncherSettingView.xaml
+++ b/Ui/View/Settings/Launcher/LauncherSettingView.xaml
@@ -13,6 +13,8 @@
         <local:ConverterHotkeyModifierKeys x:Key="ConverterHotkeyModifierKeys"></local:ConverterHotkeyModifierKeys>
     </UserControl.Resources>
     <Grid Background="{DynamicResource BackgroundBrush}">
+        <ScrollViewer>
+
         <StackPanel>
 
             <TextBlock Text="{DynamicResource Launcher}" Style="{StaticResource BlockTitleColumn}" />
@@ -161,5 +163,7 @@
 
             </StackPanel>
         </StackPanel>
+
+        </ScrollViewer>
     </Grid>
 </UserControl>

--- a/Ui/View/Settings/Theme/ThemeSettingView.xaml
+++ b/Ui/View/Settings/Theme/ThemeSettingView.xaml
@@ -10,6 +10,8 @@
              d:DataContext="{d:DesignInstance local:ThemeSettingViewModel}"
              d:DesignHeight="450" d:DesignWidth="800">
     <Grid>
+        <ScrollViewer>
+
         <StackPanel>
 
             <TextBlock Text="{DynamicResource Theme}" Style="{StaticResource BlockTitleColumn}" />
@@ -141,5 +143,7 @@
                 </ComboBox>
             </Grid>
         </StackPanel>
+
+        </ScrollViewer>
     </Grid>
 </UserControl>


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/fa47965b-f238-4174-9cab-7d34c6d87087

After:

https://github.com/user-attachments/assets/181d624c-6e91-4567-83ad-5e1eb530abda

Same for Launcher, Database, and Theme.

I didn't change the indentation of the original content. That would make the difference unnecessarily large.