### PR TITLE
fix: KiTTY session file selection dialog in Serial form does not appear

### DIFF
--- a/Ui/View/Editor/Forms/SerialFormView.xaml.cs
+++ b/Ui/View/Editor/Forms/SerialFormView.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System.Windows;
 using System.Windows.Controls;
+using _1RM.Utils;
 using _1RM.Utils.KiTTY;
 using _1RM.Utils.KiTTY.Model;
 using Shawn.Utils.Wpf.FileSystem;
@@ -16,18 +17,18 @@ namespace _1RM.View.Editor.Forms
 
         private void ButtonSelectSessionConfigFile_OnClick(object sender, RoutedEventArgs e)
         {
-            if (DataContext is IKittyConnectable pc)
+            if (DataContext is SerialFormViewModel vm)
             {
                 var path = SelectFileHelper.OpenFile(filter: "KiTTY Session|*.*");
                 if (path == null) return;
-                if (File.Exists(path)
-                    && KittyConfig.Read(path)?.Count > 0)
+                if (File.Exists(path) && KittyConfig.Read(path)?.Count > 0)
                 {
-                    pc.ExternalKittySessionConfigPath = path;
+                    vm.New.ExternalKittySessionConfigPath = path;
                 }
                 else
                 {
-                    pc.ExternalKittySessionConfigPath = "";
+                    vm.New.ExternalKittySessionConfigPath = "";
+                    MessageBoxHelper.Warning("Invalid KiTTY session config file.");
                 }
             }
         }


### PR DESCRIPTION
Similar fix as in 9514fcd
The Serial form had the same problem as SSH, so I fixed it the same way.