### PR TITLE
Fix ShowFolder's anomaly handling (Fix #841)

### DIFF
--- a/Ui/Model/Protocol/FileTransmit/Transmitters/TransmitterFtp.cs
+++ b/Ui/Model/Protocol/FileTransmit/Transmitters/TransmitterFtp.cs
@@ -242,6 +242,13 @@ namespace _1RM.Model.Protocol.FileTransmit.Transmitters
             _ftp = new AsyncFtpClient(Hostname, new System.Net.NetworkCredential(Username, Password), Port);
             _ftp.Config.Noop = true;
             await _ftp.AutoConnect();
+            if (!_ftp.IsConnected)
+            {
+                await _ftp.Disconnect();
+                _ftp.Dispose();
+                _ftp = null;
+                throw new Exception("Couldn't connect to the server.");
+            }
         }
     }
 }

--- a/Ui/View/Host/ProtocolHosts/VmFileTransmitHost.cs
+++ b/Ui/View/Host/ProtocolHosts/VmFileTransmitHost.cs
@@ -215,55 +215,65 @@ namespace _1RM.View.Host.ProtocolHosts
                         }
                     }
 
+                    ObservableCollection<RemoteItem>? remoteItemInfos = null;
                     try
                     {
-                        var remoteItemInfos = new ObservableCollection<RemoteItem>();
-                        //SimpleLogHelper.Debug($"ShowFolder before ListDirectoryItems");
-                        var items = await Trans.ListDirectoryItems(path);
-                        if (Enumerable.Any<RemoteItem>(items))
+                        if (await Trans.Exists(path))
                         {
-                            remoteItemInfos = new ObservableCollection<RemoteItem>(items);
-                        }
-
-                        RemoteItems = remoteItemInfos;
-                        //SimpleLogHelper.Debug($"ShowFolder before MakeRemoteItemsOrderBy");
-                        MakeRemoteItemsOrderBy();
-
-                        if (path != CurrentPath)
-                        {
-                            if (mode == 0
-                                && (_pathHistoryPrevious.Count == 0 || _pathHistoryPrevious.Peek() != CurrentPath))
+                            //SimpleLogHelper.Debug($"ShowFolder before ListDirectoryItems");
+                            var items = await Trans.ListDirectoryItems(path);
+                            if (Enumerable.Any<RemoteItem>(items))
                             {
-                                _pathHistoryPrevious.Push(CurrentPath);
-                                if (_pathHistoryFollowing.Count > 0 &&
-                                    _pathHistoryFollowing.Peek() != path)
-                                    _pathHistoryFollowing.Clear();
+                                remoteItemInfos = new ObservableCollection<RemoteItem>(items);
                             }
-
-                            CurrentPath = path;
                         }
-
-                        if (CurrentPath != "/" && CurrentPath != "")
-                            CmdGoToPathParentEnable = true;
                         else
-                            CmdGoToPathParentEnable = false;
-
-                        CmdGoToPathPreviousEnable = _pathHistoryPrevious.Count > 0;
-                        CmdGoToPathFollowingEnable = _pathHistoryFollowing.Count > 0;
-
-                        if (showIoMessage)
                         {
-                            IoMessageLevel = IoMessageLevelNormal;
-                            IoMessage = $"ls {CurrentPath}";
+                            IoMessageLevel = IoMessageLevelError;
+                            IoMessage = $"ls {path}: Not exists";
                         }
                     }
                     catch (Exception e)
                     {
                         IoMessageLevel = IoMessageLevelError;
                         IoMessage = $"ls {CurrentPath}: " + e.Message;
-                        if (CurrentPath != path)
-                            ShowFolder(CurrentPath, showIoMessage: false);
-                        return;
+                    }
+                    finally
+                    {
+                        if (remoteItemInfos != null)
+                        {
+                            RemoteItems = remoteItemInfos;
+                            //SimpleLogHelper.Debug($"ShowFolder before MakeRemoteItemsOrderBy");
+                            MakeRemoteItemsOrderBy();
+
+                            if (path != CurrentPath)
+                            {
+                                if (mode == 0
+                                    && (_pathHistoryPrevious.Count == 0 || _pathHistoryPrevious.Peek() != CurrentPath))
+                                {
+                                    _pathHistoryPrevious.Push(CurrentPath);
+                                    if (_pathHistoryFollowing.Count > 0 &&
+                                        _pathHistoryFollowing.Peek() != path)
+                                        _pathHistoryFollowing.Clear();
+                                }
+
+                                CurrentPath = path;
+                            }
+
+                            if (CurrentPath != "/" && CurrentPath != "")
+                                CmdGoToPathParentEnable = true;
+                            else
+                                CmdGoToPathParentEnable = false;
+
+                            CmdGoToPathPreviousEnable = _pathHistoryPrevious.Count > 0;
+                            CmdGoToPathFollowingEnable = _pathHistoryFollowing.Count > 0;
+
+                            if (showIoMessage)
+                            {
+                                IoMessageLevel = IoMessageLevelNormal;
+                                IoMessage = $"ls {CurrentPath}";
+                            }
+                        }
                     }
                 }
                 finally


### PR DESCRIPTION
This fixes #841 
- Update the remote item view only when the items are successfully retrieved. When an exception is caught, do not make any changes.
- Since it is not possible to distinguish between cases where the referenced directory does not exist and cases where the contents of the referenced directory are empty, check the existence of the directory before retrieving the item list, and display an error if it does not exist.
- Add code to throw an exception if FTP connect fails.
