### PR TITLE
Prevent Volume Mixer from picking up the session icons

### DIFF
--- a/Ui/App.xaml.cs
+++ b/Ui/App.xaml.cs
@@ -68,7 +68,7 @@ namespace _1RM
 
             // First, make a sound (one second of silence) in the main window
             // so that the Volume Mixer and others will recognize 1Remote as
-            // an application that produces sound.
+            // an application that outputs sound.
             //
             // Otherwise, 1Remote is only be detected as a sound application
             // when an RDP session is started. However, it seemed odd that it
@@ -78,17 +78,6 @@ namespace _1RM
             // So while this application is running, from start to finish,
             // it's better to be visible as a sound application in the Volume
             // Mixer and others.
-            //
-            // Additionally, there was another issue where the Volume Mixer
-            // would display the RDP session icon and remain in that state
-            // forever. It appears that the Volume Mixer continues to use the
-            // icon that it first retrieved. So, by first playing the sound in
-            // the main window first, we can get Volume Mixer to display the
-            // application icon and keep it there.
-            //System.Media.SoundPlayer player = new System.Media.SoundPlayer("Resources/dummy.wav");
-            //player.Play();
-
-            // Set dummy.wav as a resource to avoid copy the file to the output folder when build.
             var sri = Application.GetResourceStream(new Uri("pack://application:,,,/Resources/dummy.wav"));
             if (sri != null)
             {


### PR DESCRIPTION
Additional solution for #310
I think it's perfect now.
