### PR TITLE
Fix: Escape special characters in the target string

### DIFF
--- a/scripts/Set-Secret.ps1
+++ b/scripts/Set-Secret.ps1
@@ -64,9 +64,13 @@ if ($isRevert) {
 }
 
 $fileLines = Get-Content $filePath
+
+# Escape special characters in the target string
+$escapedTarget = [regex]::Escape($target)
+
 $matched = 0
 foreach ($l in $fileLines) {
-    if($l -match $target) {
+    if($l -match $escapedTarget) {
         $matched = 1
         break
     }
@@ -83,7 +87,7 @@ if (!$matched) {
 }
 
 # Replace the content of the file
-(Get-Content $filePath) -Replace $target, $replacement | Set-Content $filePath
+(Get-Content $filePath) -Replace $escapedTarget, $replacement | Set-Content $filePath
 
 # Set the current directory back to the original location
 Set-Location $originalDirectory


### PR DESCRIPTION
When the content of Salt.txt contains parentheses, the following PowerShell command fails to execute properly:

`powershell.exe ..\scripts\Set-Secret.ps1 -filePath .\Ui\Assert.cs -Pattern "===REPLACE_ME_WITH_SALT===" -localSecretFilePath "C:\1Remote_Secret\Salt.txt" -isRevert`