### PR TITLE
fix: #1053 countermeasure for Youdao

### DIFF
--- a/Ui/Utils/WindowsApi/WindowsVersionHelper.cs
+++ b/Ui/Utils/WindowsApi/WindowsVersionHelper.cs
@@ -78,5 +78,6 @@ namespace _1RM.Utils.WindowsApi
         public const int WM_ENABLE = 0x000A;
         public const int WM_CANCELMODE = 0x001F;
         public const int WM_MOUSEACTIVATE = 0x0021;
+        public const int WM_GETOBJECT = 0x003D;
     }
 }

--- a/Ui/View/Host/ProtocolHosts/AxMsRdpClient09Host.xaml.cs
+++ b/Ui/View/Host/ProtocolHosts/AxMsRdpClient09Host.xaml.cs
@@ -43,6 +43,13 @@ namespace _1RM.View.Host.ProtocolHosts
     {
         protected override void WndProc(ref System.Windows.Forms.Message m)
         {
+            // Falsifying the response to WM_GETOBJECT to resolve issue #1053 that the RDP client to crash when using the word capture feature
+            if (m.Msg == Win32Api.WM_GETOBJECT)
+            {
+                m.Result = -1; // Setting it to IntPtr.Zero (or 0) did not resolve the issue.
+                               // Setting it experimentally to 1 or -1 solved the problem, though I cannot explain why.
+                return;
+            }
             // Fix for the missing focus issue on the rdp client component
             if (m.Msg == Win32Api.WM_MOUSEACTIVATE)
             {


### PR DESCRIPTION
Falsifying the response to WM_GETOBJECT to resolve issue #1053 that the RDP client to crash when using the Youdao.